### PR TITLE
Support for display of individual printrequest labels

### DIFF
--- a/src/ByHttpRequest/QueryResultFetcher.php
+++ b/src/ByHttpRequest/QueryResultFetcher.php
@@ -93,6 +93,9 @@ class QueryResultFetcher {
 			$property->setInterwiki( $querySource );
 
 			$printrequests->getData()->setDataItem( $property );
+
+			// Reset label after dataItem was re-added
+			$printrequests->setLabel( $printrequests->getLabel() );
 		}
 
 		$result = $this->doMakeHttpRequestFor( $query );


### PR DESCRIPTION
Requires https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/1281

```
{{#ask: [[RecordApiTest]]
 |?Has number=Number
 |source=mw-2501
}}

{{#ask: [[Modification date::+]]
 |?Modification date
 |?Modification date=DateLabelToBeTheAPIOutputReference
 |source=mw-2501
}}
```
