### PR TITLE
Add HttpResponseCache support, refs #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ box to choose from external query sources.
 
 ## Configuration
 
+### Endpoint
+
 For a `#ask` query to retrieve results from a remote location, an external source is required to be registered
 with an arbitrary key to be assigned to a lookup processor such as:
 
@@ -80,6 +82,12 @@ $GLOBALS['seqlgExternalRepositoryEndpoints'] = array(
     )
 );
 ````
+### Cache
+
+`$GLOBALS['seqlgHttpResponseCacheType']` allows to specify a cache type (using `CACHE_NONE` will disable
+the caching completely and reroute each request to the selected endpoint) to filter repeated requests
+of the same signature (== same query to the same API endpoint) and return responses from cache for the time
+specified in `$GLOBALS['seqlgHttpResponseCacheLifetime']`.
 
 ## Contribution and support
 

--- a/SemanticExternalQueryLookup.php
+++ b/SemanticExternalQueryLookup.php
@@ -45,6 +45,23 @@ call_user_func( function () {
 	// Register message files
 	$GLOBALS['wgMessagesDirs']['semantic-external-query-lookup'] = __DIR__ . '/i18n';
 
+	/**
+	 * Specifies how long a response is cached before a new request is routed
+	 * to the endpoint. This avoids that repeated requests with the same signature
+	 * are made to an endpoint.
+	 *
+	 * This is important if the endpoint has an API access request limitation.
+	 */
+	$GLOBALS['seqlgHttpResponseCacheLifetime'] = 60 * 5; // in seconds
+
+	/**
+	 * Type of the cache to be used, using CACHE_NONE will disable the caching
+	 * and reroutes every request to the endpoint.
+	 *
+	 * @see https://www.mediawiki.org/wiki/Manual:$wgMainCacheType
+	 */
+	$GLOBALS['seqlgHttpResponseCacheType'] = CACHE_ANYTHING;
+
 	$GLOBALS['seqlgExternalRepositoryEndpoints'] = array();
 
 	// Finalize extension setup

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"php": ">=5.3.0",
 		"composer/installers": "1.*,>=1.0.1",
 		"mediawiki/semantic-media-wiki": "@dev",
-		"onoi/http-request": "~1.2"
+		"onoi/http-request": "~1.3"
 	},
 	"require-dev": {
 		"mediawiki/semantic-media-wiki": "@dev",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,4 +25,7 @@
             <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
+    <php>
+       <var name="seqlgHttpResponseCacheType" value="hash"/>
+    </php>
 </phpunit>

--- a/src/ByAskApiHttpRequest/QueryResultFetcher.php
+++ b/src/ByAskApiHttpRequest/QueryResultFetcher.php
@@ -41,6 +41,16 @@ class QueryResultFetcher {
 	private $repositoryTargetUrl = '';
 
 	/**
+	 * @var string
+	 */
+	private $httpResponseCachePrefix;
+
+	/**
+	 * @var integer
+	 */
+	private $httpResponseCacheLifetime;
+
+	/**
 	 * @since 1.0
 	 *
 	 * @param HttpRequestFactory $httpRequestFactory
@@ -69,6 +79,24 @@ class QueryResultFetcher {
 	 */
 	public function setRepositoryTargetUrl( $repositoryTargetUrl ) {
 		$this->repositoryTargetUrl = $repositoryTargetUrl;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param string $httpResponseCachePrefix
+	 */
+	public function setHttpResponseCachePrefix( $httpResponseCachePrefix ) {
+		$this->httpResponseCachePrefix = $httpResponseCachePrefix;
+	}
+
+	/**
+	 * @since 1.0
+	 *
+	 * @param integer $httpResponseCacheLifetime
+	 */
+	public function setHttpResponseCacheLifetime( $httpResponseCacheLifetime ) {
+		$this->httpResponseCacheLifetime = $httpResponseCacheLifetime;
 	}
 
 	/**
@@ -129,7 +157,10 @@ class QueryResultFetcher {
 
 	private function doMakeHttpRequestFor( $query ) {
 
-		$httpRequest = $this->httpRequestFactory->newCurlRequest();
+		$httpRequest = $this->httpRequestFactory->newCachedCurlRequest();
+
+		$httpRequest->setOption( ONOI_HTTP_REQUEST_RESPONSECACHE_TTL, $this->httpResponseCacheLifetime );
+		$httpRequest->setOption( ONOI_HTTP_REQUEST_RESPONSECACHE_PREFIX, $this->httpResponseCachePrefix . ':' );
 
 		$httpRequest->setOption( CURLOPT_FOLLOWLOCATION, true );
 

--- a/tests/phpunit/Unit/ByAskApiHttpRequest/QueryResultFetcherTest.php
+++ b/tests/phpunit/Unit/ByAskApiHttpRequest/QueryResultFetcherTest.php
@@ -18,6 +18,7 @@ use SMW\DIWikiPage;
 class QueryResultFetcherTest extends \PHPUnit_Framework_TestCase {
 
 	private $store;
+	private $httpRequest;
 	private $httpRequestFactory;
 	private $jsonResponseParser;
 
@@ -27,7 +28,7 @@ class QueryResultFetcherTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
+		$this->httpRequest = $this->getMockBuilder( '\Onoi\HttpRequest\HttpRequest' )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -36,8 +37,8 @@ class QueryResultFetcherTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$this->httpRequestFactory->expects( $this->any() )
-			->method( 'newCurlRequest' )
-			->will( $this->returnValue( $httpRequest ) );
+			->method( 'newCachedCurlRequest' )
+			->will( $this->returnValue( $this->httpRequest ) );
 
 		$this->jsonResponseParser = $this->getMockBuilder( '\SEQL\ByAskApiHttpRequest\JsonResponseParser' )
 			->disableOriginalConstructor()
@@ -97,6 +98,72 @@ class QueryResultFetcherTest extends \PHPUnit_Framework_TestCase {
 			$queryResultFactory,
 			$this->jsonResponseParser
 		);
+
+		$this->assertInstanceOf(
+			'\SMWQueryResult',
+			$instance->fetchQueryResult( $query )
+		);
+	}
+
+	public function testFetchQueryResultWithResponseCache() {
+
+		$queryResultFactory = new QueryResultFactory( $this->store );
+
+		$printRequest = $this->getMockBuilder( '\SMW\Query\PrintRequest' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$printRequest->expects( $this->any() )
+			->method( 'getSerialisation' )
+			->will( $this->returnValue( '?ABC' ) );
+
+		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$description->expects( $this->any() )
+			->method( 'getPrintrequests' )
+			->will( $this->returnValue( array( $printRequest ) ) );
+
+		$query = $this->getMockBuilder( '\SMWQuery' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getSortKeys' )
+			->will( $this->returnValue( array() ) );
+
+		$query->expects( $this->any() )
+			->method( 'getExtraPrintouts' )
+			->will( $this->returnValue( array( $printRequest ) ) );
+
+		$query->expects( $this->any() )
+			->method( 'getDescription' )
+			->will( $this->returnValue( $description ) );
+
+		$instance = new QueryResultFetcher(
+			$this->httpRequestFactory,
+			$queryResultFactory,
+			$this->jsonResponseParser
+		);
+
+		$instance->setHttpResponseCacheLifetime( 42 );
+		$instance->setHttpResponseCachePrefix( 'Foo' );
+
+		// PHUNIT 4.1
+	//	$this->httpRequest->expects( $this->any() )
+	//		->method( 'setOption' )
+	//		->withConsecutive(
+	//			array( $this->anything(), $this->equalTo( 42 ) ),
+	//			array( $this->anything(), $this->equalTo( 'Foo:' ) ) );
+
+		$this->httpRequest->expects( $this->at( 0 ) )
+			->method( 'setOption' )
+			->with( $this->anything(), $this->equalTo( 42 ) );
+
+		$this->httpRequest->expects( $this->at( 1 ) )
+			->method( 'setOption' )
+			->with( $this->anything(), $this->equalTo( 'Foo:' ) );
 
 		$this->assertInstanceOf(
 			'\SMWQueryResult',


### PR DESCRIPTION
- `$GLOBALS['seqlgHttpResponseCacheLifetime']` to specify how long
  a response should be cached (5 min by default)
- `$GLOBALS['seqlgHttpResponseCacheType']` specifies the cache type
  (`CACHE_ANYTHING` as default)

refs #5
