### PR TITLE
Update SemanticExternalQueryLookup.php

### DIFF
--- a/SemanticExternalQueryLookup.php
+++ b/SemanticExternalQueryLookup.php
@@ -43,7 +43,7 @@ class SemanticExternalQueryLookup {
 
 		// Register extension info
 		$GLOBALS['wgExtensionCredits']['semantic'][] = array(
-			'path'           => __DIR__,
+			'path'           => __FILE__,
 			'name'           => 'Semantic External Query Lookup',
 			'author'         => array( 'James Hong Kong' ),
 			'url'            => 'https://github.com/SemanticMediaWiki/SemanticExternalQueryLookup/',


### PR DESCRIPTION
Allow the git hash and time stamp of the version to be shown on "Special:Version"

Refs issue https://github.com/SemanticMediaWiki/SemanticBreadcrumbLinks/issues/19
