### PR TITLE
Add seql-name system message for the extension name

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -6,6 +6,7 @@
 	],
 	"url": "https://www.mediawiki.org/wiki/Extension:SemanticExternalQueryLookup",
 	"descriptionmsg": "seql-desc",
+	"namemsg": "seql-name",
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6,6 +6,7 @@
 		]
 	},
 	"seql-desc": "Allows to integrate query results from a remote [https://semantic-mediawiki.org Semantic MediaWiki] into a local wiki",
+	"seql-name": "Semantic External Query Lookup",
 	"seql-interwiki-prefix-is-missing": "The selected \"$1\" source is missing a matching interwiki prefix.",
 	"seql-debug-query-not-supported": "The display of results for a debug query is not supported when using an external query source."
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -6,6 +6,7 @@
 		]
 	},
 	"seql-desc": "{{desc|name=Semantic External Query Lookup|url=https://www.mediawiki.org/wiki/Extension:Semantic_External_Query_Lookup}}",
+	"seql-name": "{{notranslate}}\nName of the extension as it should be displayed.",
 	"seql-interwiki-prefix-is-missing": "This is an error message.\n\n* $1 holds the label of the configured query source.",
 	"seql-debug-query-not-supported": "This is an error message."
 }


### PR DESCRIPTION
Registers the extension name as a system message via namemsg, following the pattern of the Semantic Extra Special Properties extension.